### PR TITLE
Add aliases for common package manager commands via bin/docker

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -61,6 +61,12 @@ alias dcrw='docker-compose run --rm web'
 alias dcu='docker-compose up'
 alias dsp='docker system prune'
 
+# docker & package managers
+alias bdn='bin/docker/npm'
+alias bdni='bin/docker/npm install'
+alias bdy='bin/docker/yarn'
+alias bdya='bin/docker/yarn add'
+
 # Lock the screen (when going AFK)
 alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend"
 


### PR DESCRIPTION
I find myself writing these a lot... 

`bin/docker/yarn add` & `bin/docker/npm install`

Thought they might be useful to add into the aliases file?